### PR TITLE
Community: GitHub Discussions integration + redesigned Community page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,25 @@
 # Contributing to AI History in the Making
 
-This is an open-source, community-driven record of the AI revolution. All debates happen on GitHub — what gets merged becomes the record.
+This is an open-source, community-driven record of the AI revolution. Community happens on GitHub — what gets merged becomes the record.
 
-## Issues vs. Pull Requests — When to Use Which
+## Discussions vs Issues vs Pull Requests
 
-### Open an Issue when you want to:
-- **Debate or discuss** — "I think this question is marked wrong" or "Was ChatGPT really the inflection point?"
-- **Propose something** without writing the change yourself — "We're missing event X" or "This analysis is wrong because Y"
-- **Challenge existing content** — disagree with a resolution status, question the framing of an event, or contest the analysis
-- **Ask a question** — "Should we add a section on AI safety?"
+We use **three channels** — pick the right one:
 
-**→ Issues are for talking. No code/data changes needed.**
+### Start a [Discussion](https://github.com/Deva-me-AI/AI-History-in-the-Making/discussions) when you want to:
+- **Debate or discuss** — "Is the AI bubble sustainable?" or "What's the most important event we're missing?"
+- **Ask open questions** — "Should we add a robotics section?" or "How should we handle contested claims?"
+- **Share perspectives** — your take on AI trends, interpretations, or what the timeline gets right/wrong
+- **Community conversation** — anything that doesn't need a specific code change
+
+**→ Discussions are for conversation. No code changes needed.**
+
+### Open an [Issue](https://github.com/Deva-me-AI/AI-History-in-the-Making/issues) when you want to:
+- **Report a factual error** — "The First AI Winter date is wrong (1969 should be 1973)"
+- **Flag a missing event** — "AlphaFold 2 should be on the timeline"
+- **Propose a specific fix** — wrong date, broken source link, inaccurate description
+
+**→ Issues are for actionable fixes that need a PR to resolve.**
 
 ### Open a Pull Request when you want to:
 - **Add content** — you've written the timeline event or question and it's ready to merge

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Documenting the fastest technological revolution in human history — milestones
 
 All content lives in simple JSON files. Anyone can contribute — add events, update question resolutions, challenge the analysis, or propose entirely new questions.
 
-**All debates happen on GitHub.** What gets merged becomes the record.
+**Community happens on GitHub:**
+- **[Discussions](https://github.com/Deva-me-AI/AI-History-in-the-Making/discussions)** — Open debates, questions, and community conversation about AI history
+- **[Issues](https://github.com/Deva-me-AI/AI-History-in-the-Making/issues)** — Actionable fixes: wrong dates, missing events, factual errors
+- **What gets merged becomes the record.**
 
 ## Contributing
 
@@ -48,21 +51,21 @@ Edit `data/questions.json` and add:
 
 Status values: `resolved`, `partial`, `open`
 
-### Contesting / Debating Content
+### Debating & Discussing
 
-**Disagree with a resolution? Think an event is wrong or missing? Want to challenge the analysis?**
+**Want to debate AI history or challenge the analysis?**
 
-1. **[Open an Issue](https://github.com/Deva-me-AI/AI-History-in-the-Making/issues/new)** — describe what you think is wrong and provide evidence
-2. The community debates in the issue thread
-3. If there's consensus, someone opens a PR with the fix
-4. What gets merged = the record
+→ **[Start a Discussion](https://github.com/Deva-me-AI/AI-History-in-the-Making/discussions/new)** for open-ended debates, questions, and conversation
 
-Use labels to categorize your issue:
-- `timeline` — contesting or adding timeline events
-- `questions` — contesting question status, evidence, or analysis
-- `debate` — broader debates about AI trends or interpretations
+→ **[Open an Issue](https://github.com/Deva-me-AI/AI-History-in-the-Making/issues/new)** for actionable fixes (wrong dates, missing events, factual errors)
 
-**Active debates show up on the [Debates page](https://www.aihistoricunfolding.com/debates) of the site**, linking directly to GitHub issues so everyone can follow and participate.
+**When to use Discussions vs Issues:**
+- **Discussions** — "Is the AI bubble real?", "Should we add robotics events?", "What's the most important event we're missing?" — open questions with no single right answer
+- **Issues** — "The First AI Winter date is wrong (1969 should be 1973)", "Missing event: AlphaFold 2" — specific errors that need a data change
+
+When a Discussion reaches consensus on something actionable, it gets converted to an Issue → PR → merged.
+
+**Active debates show up on the [Community page](https://www.aihistoricunfolding.com/debates) of the site**, linking to both GitHub Discussions and Issues.
 
 ### What Gets Merged
 

--- a/src/app/debates/page.tsx
+++ b/src/app/debates/page.tsx
@@ -32,8 +32,10 @@ const labelStyles: Record<string, string> = {
   timeline: "bg-blue-500/20 text-blue-300 border-blue-500/30",
   questions: "bg-purple-500/20 text-purple-300 border-purple-500/30",
   debate: "bg-amber-500/20 text-amber-300 border-amber-500/30",
-  bug: "bg-red-500/20 text-red-300 border-red-500/30",
-  enhancement: "bg-green-500/20 text-green-300 border-green-500/30",
+  accuracy: "bg-red-500/20 text-red-300 border-red-500/30",
+  "missing-event": "bg-orange-500/20 text-orange-300 border-orange-500/30",
+  "convergence-review":
+    "bg-purple-500/20 text-purple-300 border-purple-500/30",
 };
 
 function timeAgo(dateStr: string): string {
@@ -56,36 +58,68 @@ function truncateBody(body: string | null, maxLen = 200): string {
   const cleaned = body
     .replace(/\r\n/g, " ")
     .replace(/\n/g, " ")
-    // Strip markdown formatting
-    .replace(/\*\*([^*]+)\*\*/g, "$1")        // **bold**
-    .replace(/\*([^*]+)\*/g, "$1")             // *italic*
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")   // [text](url)
-    .replace(/#{1,6}\s/g, "")                  // headings
-    .replace(/---+/g, "")                      // horizontal rules
-    .replace(/📖[^|]*/g, "")                   // source citations
-    .replace(/\|/g, " · ")                     // pipe separators
-    .replace(/\s{2,}/g, " ")                   // collapse whitespace
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/#{1,6}\s/g, "")
+    .replace(/---+/g, "")
+    .replace(/\|/g, " · ")
+    .replace(/\s{2,}/g, " ")
     .trim();
   if (cleaned.length <= maxLen) return cleaned;
   return cleaned.slice(0, maxLen) + "…";
 }
 
-export default function DebatesPage() {
+const discussionCategories = [
+  {
+    name: "Open Questions",
+    description:
+      "Will AI replace programmers? Is RAG obsolete? Are we in a bubble? Debate the big questions.",
+    emoji: "💡",
+    url: `${REPO_URL}/discussions/categories/ideas`,
+    color: "from-amber-500/10 to-orange-500/10 border-amber-500/20",
+  },
+  {
+    name: "Debates",
+    description:
+      "Open-ended debates about AI trends, interpretations, and what it all means.",
+    emoji: "💬",
+    url: `${REPO_URL}/discussions/categories/general`,
+    color: "from-blue-500/10 to-indigo-500/10 border-blue-500/20",
+  },
+  {
+    name: "Q&A",
+    description:
+      "Ask questions about the timeline, methodology, or AI history in general.",
+    emoji: "🙏",
+    url: `${REPO_URL}/discussions/categories/q-a`,
+    color: "from-green-500/10 to-emerald-500/10 border-green-500/20",
+  },
+  {
+    name: "Announcements",
+    description:
+      "Major updates, new features, and milestones for the project.",
+    emoji: "📢",
+    url: `${REPO_URL}/discussions/categories/announcements`,
+    color: "from-purple-500/10 to-pink-500/10 border-purple-500/20",
+  },
+];
+
+export default function CommunityPage() {
   const [issues, setIssues] = useState<GitHubIssue[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filter, setFilter] = useState<"all" | "open" | "closed">("all");
+  const [tab, setTab] = useState<"discussions" | "issues">("discussions");
 
   useEffect(() => {
     async function fetchIssues() {
       try {
-        // Fetch both open and closed issues
         const [openRes, closedRes] = await Promise.all([
           fetch(
-            `https://api.github.com/repos/${REPO}/issues?state=open&per_page=50&sort=updated&direction=desc`
+            `https://api.github.com/repos/${REPO}/issues?state=open&per_page=30&sort=updated&direction=desc`
           ),
           fetch(
-            `https://api.github.com/repos/${REPO}/issues?state=closed&per_page=30&sort=updated&direction=desc`
+            `https://api.github.com/repos/${REPO}/issues?state=closed&per_page=20&sort=updated&direction=desc`
           ),
         ]);
 
@@ -96,7 +130,6 @@ export default function DebatesPage() {
         const openIssues: GitHubIssue[] = await openRes.json();
         const closedIssues: GitHubIssue[] = await closedRes.json();
 
-        // Filter out pull requests (they also show up in issues API)
         const allIssues = [...openIssues, ...closedIssues]
           .filter((i) => !("pull_request" in i))
           .sort(
@@ -118,197 +151,250 @@ export default function DebatesPage() {
     fetchIssues();
   }, []);
 
-  const filteredIssues = issues.filter((i) => {
-    if (filter === "all") return true;
-    return i.state === filter;
-  });
-
   const openCount = issues.filter((i) => i.state === "open").length;
   const closedCount = issues.filter((i) => i.state === "closed").length;
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-16">
-      <h1 className="text-4xl font-bold mb-4">Debates</h1>
-      <p className="text-gray-400 mb-4 max-w-2xl">
-        Active and resolved debates about AI history — contested events,
-        questioned resolutions, and broader discussions. All debates happen on
-        GitHub.
-      </p>
-      <p className="text-gray-500 text-sm mb-8">
-        Disagree with something on this site?{" "}
-        <a
-          href={`${REPO_URL}/issues/new`}
-          className="text-blue-400 hover:text-blue-300"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Open an issue
-        </a>{" "}
-        to start a debate. The community discusses, evidence is weighed, and
-        what gets merged becomes the record.
+      <h1 className="text-4xl font-bold mb-4">Community</h1>
+      <p className="text-gray-400 mb-6 max-w-2xl">
+        Debate AI history, challenge the analysis, and help build the record.
+        All contributions happen on GitHub.
       </p>
 
-      {/* Filter tabs */}
+      {/* How it works banner */}
+      <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 mb-8">
+        <div className="flex items-start gap-3">
+          <div className="text-xl mt-0.5">📋</div>
+          <div>
+            <h3 className="font-medium text-gray-200 text-sm mb-2">
+              How this works
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs text-gray-400">
+              <div className="flex items-start gap-2">
+                <span className="text-green-400 font-bold mt-px">💬</span>
+                <div>
+                  <span className="text-gray-300 font-medium">
+                    Discussions
+                  </span>{" "}
+                  — Open debates, questions, and community conversation about
+                  AI history and trends.
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="text-blue-400 font-bold mt-px">📝</span>
+                <div>
+                  <span className="text-gray-300 font-medium">Issues</span>{" "}
+                  — Actionable fixes: wrong dates, missing events, factual
+                  errors that need a PR to resolve.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tab navigation */}
       <div className="flex items-center gap-1 mb-8 border-b border-gray-800 pb-px">
         <button
-          onClick={() => setFilter("all")}
+          onClick={() => setTab("discussions")}
           className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-            filter === "all"
+            tab === "discussions"
               ? "text-white border-purple-500"
               : "text-gray-500 border-transparent hover:text-gray-300"
           }`}
         >
-          All ({issues.length})
+          💬 Discussions
         </button>
         <button
-          onClick={() => setFilter("open")}
+          onClick={() => setTab("issues")}
           className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-            filter === "open"
-              ? "text-white border-green-500"
+            tab === "issues"
+              ? "text-white border-blue-500"
               : "text-gray-500 border-transparent hover:text-gray-300"
           }`}
         >
-          🟢 Open ({openCount})
-        </button>
-        <button
-          onClick={() => setFilter("closed")}
-          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-            filter === "closed"
-              ? "text-white border-gray-500"
-              : "text-gray-500 border-transparent hover:text-gray-300"
-          }`}
-        >
-          ✅ Resolved ({closedCount})
+          📝 Issues ({openCount} open, {closedCount} resolved)
         </button>
       </div>
 
-      {/* Loading state */}
-      {loading && (
-        <div className="text-center py-16">
-          <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-gray-600 border-t-purple-500" />
-          <p className="text-gray-500 mt-4 text-sm">
-            Loading debates from GitHub...
-          </p>
-        </div>
-      )}
+      {/* Discussions tab */}
+      {tab === "discussions" && (
+        <div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+            {discussionCategories.map((cat) => (
+              <a
+                key={cat.name}
+                href={cat.url}
+                className={`block rounded-xl border bg-gradient-to-br ${cat.color} p-5 transition-all hover:scale-[1.02] hover:shadow-lg`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <span className="text-2xl">{cat.emoji}</span>
+                  <h3 className="font-semibold text-gray-200">{cat.name}</h3>
+                </div>
+                <p className="text-gray-400 text-sm leading-relaxed">
+                  {cat.description}
+                </p>
+                <div className="mt-3 text-xs text-gray-500">
+                  View on GitHub →
+                </div>
+              </a>
+            ))}
+          </div>
 
-      {/* Error state */}
-      {error && (
-        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-center">
-          <p className="text-red-400 mb-2">Couldn&apos;t load issues: {error}</p>
-          <a
-            href={`${REPO_URL}/issues`}
-            className="text-blue-400 hover:text-blue-300 text-sm"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            View issues directly on GitHub →
-          </a>
-        </div>
-      )}
-
-      {/* Empty state */}
-      {!loading && !error && filteredIssues.length === 0 && (
-        <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-12 text-center">
-          <div className="text-4xl mb-4">🤔</div>
-          <h3 className="text-lg font-semibold mb-2">No debates yet</h3>
-          <p className="text-gray-400 text-sm mb-4">
-            {filter === "all"
-              ? "Be the first to start a debate about AI history."
-              : filter === "open"
-              ? "No open debates right now."
-              : "No resolved debates yet."}
-          </p>
-          <a
-            href={`${REPO_URL}/issues/new`}
-            className="inline-flex items-center gap-2 rounded-lg bg-gray-800 px-5 py-2.5 text-sm font-medium text-gray-200 transition-colors hover:bg-gray-700"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            📝 Start a Debate
-          </a>
-        </div>
-      )}
-
-      {/* Issues list */}
-      {!loading && !error && filteredIssues.length > 0 && (
-        <div className="space-y-4">
-          {filteredIssues.map((issue) => (
+          <div className="text-center">
             <a
-              key={issue.number}
-              href={issue.html_url}
-              className="block rounded-xl border border-gray-800 bg-gray-900/50 p-5 question-card transition-all hover:bg-gray-900/80"
+              href={`${REPO_URL}/discussions`}
+              className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-purple-500"
               target="_blank"
               rel="noopener noreferrer"
             >
-              <div className="flex items-start gap-3">
-                {/* State indicator */}
-                <div className="mt-1 flex-shrink-0">
-                  {issue.state === "open" ? (
-                    <div className="h-4 w-4 rounded-full border-2 border-green-500" />
-                  ) : (
-                    <div className="h-4 w-4 rounded-full bg-purple-500 flex items-center justify-center">
-                      <svg
-                        viewBox="0 0 16 16"
-                        className="h-2.5 w-2.5 text-white"
-                        fill="currentColor"
-                      >
-                        <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" />
-                      </svg>
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  {/* Title + labels */}
-                  <div className="flex items-start gap-2 flex-wrap mb-1">
-                    <h3 className="font-medium text-gray-100">
-                      {issue.title}
-                    </h3>
-                    {issue.labels.map((label) => (
-                      <span
-                        key={label.name}
-                        className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${
-                          labelStyles[label.name] ||
-                          "bg-gray-500/20 text-gray-300 border-gray-500/30"
-                        }`}
-                      >
-                        {label.name}
-                      </span>
-                    ))}
-                  </div>
-
-                  {/* Body preview */}
-                  {issue.body && (
-                    <p className="text-gray-500 text-sm mb-2 leading-relaxed">
-                      {truncateBody(issue.body)}
-                    </p>
-                  )}
-
-                  {/* Meta */}
-                  <div className="flex items-center gap-3 text-xs text-gray-600">
-                    <span>#{issue.number}</span>
-                    <span>
-                      opened {timeAgo(issue.created_at)} by{" "}
-                      {issue.user.login}
-                    </span>
-                    {issue.comments > 0 && (
-                      <span className="flex items-center gap-1">
-                        💬 {issue.comments}
-                      </span>
-                    )}
-                    {issue.updated_at !== issue.created_at && (
-                      <span>updated {timeAgo(issue.updated_at)}</span>
-                    )}
-                  </div>
-                </div>
-              </div>
+              💬 Browse All Discussions
             </a>
-          ))}
+            <p className="text-gray-600 text-xs mt-3">
+              Start a new discussion, join existing debates, or just lurk.
+            </p>
+          </div>
         </div>
       )}
 
-      <ContributeCard context="Want to challenge an event, question, or analysis? Start by opening a GitHub issue." />
+      {/* Issues tab */}
+      {tab === "issues" && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-gray-500 text-sm">
+              Actionable fixes — wrong dates, missing events, factual errors.
+            </p>
+            <a
+              href={`${REPO_URL}/issues/new/choose`}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-gray-800 px-3.5 py-1.5 text-xs font-medium text-gray-300 transition-colors hover:bg-gray-700"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              📝 New Issue
+            </a>
+          </div>
+
+          {loading && (
+            <div className="text-center py-16">
+              <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-gray-600 border-t-blue-500" />
+              <p className="text-gray-500 mt-4 text-sm">
+                Loading issues from GitHub...
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-center">
+              <p className="text-red-400 mb-2">
+                Couldn&apos;t load issues: {error}
+              </p>
+              <a
+                href={`${REPO_URL}/issues`}
+                className="text-blue-400 hover:text-blue-300 text-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View issues directly on GitHub →
+              </a>
+            </div>
+          )}
+
+          {!loading && !error && issues.length === 0 && (
+            <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-12 text-center">
+              <div className="text-4xl mb-4">✨</div>
+              <h3 className="text-lg font-semibold mb-2">
+                No open issues
+              </h3>
+              <p className="text-gray-400 text-sm mb-4">
+                Everything looks accurate! Found something wrong?
+              </p>
+              <a
+                href={`${REPO_URL}/issues/new/choose`}
+                className="inline-flex items-center gap-2 rounded-lg bg-gray-800 px-5 py-2.5 text-sm font-medium text-gray-200 transition-colors hover:bg-gray-700"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                📝 Report an Issue
+              </a>
+            </div>
+          )}
+
+          {!loading && !error && issues.length > 0 && (
+            <div className="space-y-3">
+              {issues.map((issue) => (
+                <a
+                  key={issue.number}
+                  href={issue.html_url}
+                  className="block rounded-xl border border-gray-800 bg-gray-900/50 p-4 question-card transition-all hover:bg-gray-900/80"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="mt-1 flex-shrink-0">
+                      {issue.state === "open" ? (
+                        <div className="h-4 w-4 rounded-full border-2 border-green-500" />
+                      ) : (
+                        <div className="h-4 w-4 rounded-full bg-purple-500 flex items-center justify-center">
+                          <svg
+                            viewBox="0 0 16 16"
+                            className="h-2.5 w-2.5 text-white"
+                            fill="currentColor"
+                          >
+                            <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" />
+                          </svg>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start gap-2 flex-wrap mb-1">
+                        <h3 className="font-medium text-gray-100 text-sm">
+                          {issue.title}
+                        </h3>
+                        {issue.labels.map((label) => (
+                          <span
+                            key={label.name}
+                            className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${
+                              labelStyles[label.name] ||
+                              "bg-gray-500/20 text-gray-300 border-gray-500/30"
+                            }`}
+                          >
+                            {label.name}
+                          </span>
+                        ))}
+                      </div>
+
+                      {issue.body && (
+                        <p className="text-gray-500 text-xs mb-2 leading-relaxed">
+                          {truncateBody(issue.body, 160)}
+                        </p>
+                      )}
+
+                      <div className="flex items-center gap-3 text-xs text-gray-600">
+                        <span>#{issue.number}</span>
+                        <span>
+                          opened {timeAgo(issue.created_at)} by{" "}
+                          {issue.user.login}
+                        </span>
+                        {issue.comments > 0 && (
+                          <span className="flex items-center gap-1">
+                            💬 {issue.comments}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <ContributeCard context="Want to debate AI history or fix an error? Start a Discussion for debates, open an Issue for fixes." />
     </div>
   );
 }

--- a/src/components/ContributeCard.tsx
+++ b/src/components/ContributeCard.tsx
@@ -15,6 +15,14 @@ export default function ContributeCard({ context }: { context?: string }) {
           </p>
           <div className="flex flex-wrap gap-2">
             <a
+              href={`${REPO}/discussions`}
+              className="btn-secondary inline-flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-xs font-medium text-gray-300"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              💬 Join Discussion
+            </a>
+            <a
               href={`${REPO}/issues/new/choose`}
               className="btn-secondary inline-flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-xs font-medium text-gray-300"
               target="_blank"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,7 @@ const links = [
   { href: "/", label: "Home" },
   { href: "/timeline", label: "Timeline" },
   { href: "/questions", label: "Questions" },
-  { href: "/debates", label: "Debates" },
+  { href: "/debates", label: "Community" },
   { href: "/meta", label: "About" },
 ];
 

--- a/src/components/OpenSourceBanner.tsx
+++ b/src/components/OpenSourceBanner.tsx
@@ -3,7 +3,7 @@ export default function OpenSourceBanner() {
     <div className="border-b border-white/5 bg-gradient-to-r from-indigo-950/30 via-purple-950/20 to-pink-950/30">
       <div className="mx-auto max-w-5xl px-6 py-2 flex items-center justify-center gap-2 text-xs">
         <span className="inline-flex h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
-        <span className="text-gray-400">Open source — all debates happen on GitHub</span>
+        <span className="text-gray-400">Open source — debates &amp; discussions happen on GitHub</span>
         <a
           href="https://github.com/Deva-me-AI/AI-History-in-the-Making"
           className="text-indigo-400 hover:text-indigo-300 font-medium transition-colors ml-1"


### PR DESCRIPTION
## What changed

Migrated open-ended debates and questions from Issues to GitHub Discussions. Issues are now strictly for actionable fixes.

### Site updates
- **Debates page → Community page** with tabbed view:
  - **Discussions tab** (default): Category cards linking to Open Questions, Debates, Q&A, Announcements
  - **Issues tab**: Existing issue list for actionable fixes (dates, missing events, errors)
- **How it works banner** explaining Discussions vs Issues
- **Nav**: 'Debates' → 'Community'
- **ContributeCard**: Added '💬 Join Discussion' button
- **OpenSourceBanner**: Updated copy

### Docs updates
- **README**: Contributing section explains Discussions vs Issues
- **CONTRIBUTING**: Full guide on when to use Discussions vs Issues vs PRs

### Migration (already done)
- 25 debate/question issues migrated to Discussions
- Original issues closed with redirect links
- 5 actionable timeline issues kept as Issues (#13-17)
- 15 convergence review issues closed as resolved

Build verified clean.