### PR TITLE
README: add discussion/issue count badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AI History in the Making
 
+[![Discussions](https://img.shields.io/github/discussions/Deva-me-AI/AI-History-in-the-Making?label=Discussions&logo=github)](https://github.com/Deva-me-AI/AI-History-in-the-Making/discussions)
+[![Issues](https://img.shields.io/github/issues/Deva-me-AI/AI-History-in-the-Making?label=Issues&logo=github)](https://github.com/Deva-me-AI/AI-History-in-the-Making/issues)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+
 Documenting the fastest technological revolution in human history — milestones, open questions, and how fast they resolve.
 
 **Live site:** [aihistoricunfolding.com](https://www.aihistoricunfolding.com)


### PR DESCRIPTION
Adds shields.io badges showing discussion count, issue count, and license at the top of the README.