### PR TITLE
fix: remove Canadian Government AI/aerospace entry from timeline (#209)

### DIFF
--- a/data/timeline.json
+++ b/data/timeline.json
@@ -1901,19 +1901,6 @@
     "issueNumber": 207
   },
   {
-    "title": "Canadian Government Invests in AI and Aerospace Innovation",
-    "date": "2026-03-31",
-    "description": "The Government of Canada announced major investments in AI and aerospace innovation during an event in North Saanich, B.C. The funding aims to expand defense research capacity and support local companies in global supply chains, fostering growth in strategic technological sectors.",
-    "category": "Policy",
-    "sources": [
-      {
-        "url": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQF39zGkjaKYSloC5qyoz1D7flQf3vrN-s3q8lJMHPkWUD4-TNiEburBWKXT7zyZ4DkLQJhv2rQOKgRXXPKNgcgnRiyt5TPlY636MPNAAe0I-XSM6CPHkmv48HIwp-g-ikiKssVYuW2FQe7VtLYaUeDGwmt6UudS2puDUOgaRB6G0hOGbwYLz40uOWqGVAb-KLGXkpp9jQ1kJ16xnKxzsmU94b0sKU3tL41p8sekdyZnd-9eW-_b_HRB9DK4peCs7stkAfBHDXhq85rqeYNbiROQBsZUF17WUfodoAu0dLVHoETiK1y_QoMQfQ==",
-        "label": "canada.ca"
-      }
-    ],
-    "issueNumber": 209
-  },
-  {
     "title": "RSAC 2026 Analysis Highlights Agentic AI Security as Dominant Theme",
     "date": "2026-03-29",
     "description": "Post-conference reports from the RSA Conference 2026, which concluded on March 26, emphasized Agentic AI security as the year's dominant theme. Discussions focused on the evolving risks posed by autonomous AI agents in global cyber threats and the critical need for 'active defense' strategies to counter them.",


### PR DESCRIPTION
Removes the "Canadian Government Invests in AI and Aerospace Innovation" entry from the timeline. Entry did not meet inclusion criteria — routine funding announcement without specific amounts or structural impact.

Closes #209

Generated with [Claude Code](https://claude.ai/code)