### PR TITLE
chore: bump claude model to claude-opus-4-7

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: "claude-opus-4-6"
+          model: "claude-opus-4-7"
 
           direct_prompt: |
             You are reviewing a PR for the AI History in the Making project (aihistoricunfolding.com).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: "claude-opus-4-6"
+          model: "claude-opus-4-7"
 
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Automated bump of the `model:` line in `.github/workflows/claude.yml` and `claude-code-review.yml` to `claude-opus-4-7`.

Verified end-to-end on cross-eco-internal-docs (issue #186, PR #187) before this batch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)