### PR TITLE
chore: revert claude model to claude-opus-4-8 (Fable 5 pulled by Anthropic)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: "claude-fable-5"
+          model: "claude-opus-4-8"
 
           direct_prompt: |
             You are reviewing a PR for the AI History in the Making project (aihistoricunfolding.com).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: "claude-fable-5"
+          model: "claude-opus-4-8"
 
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Anthropic globally disabled claude-fable-5 on 2026-06-12 (US export-control order). Reverting CI workflows to claude-opus-4-8 to restore PR reviews/comments. Files: 2.